### PR TITLE
Typo in date/time header of logging file

### DIFF
--- a/EarthListener3v4_final.ino
+++ b/EarthListener3v4_final.ino
@@ -293,7 +293,7 @@ void loop(void)
               Serial.print("Logfile '");
               Serial.print(logFileName);
               Serial.println("' did not exist, so print titles first..."); 
-              dataFile.println("Time [DD HH:MM;SS],Temperature [°C],Humidity [%],Pressure [mBar],Altitude [m],eCO² [ppm],TVOC [ppb]");
+              dataFile.println("Time [DD HH:MM:SS],Temperature [°C],Humidity [%],Pressure [mBar],Altitude [m],eCO² [ppm],TVOC [ppb]");
               logFileExists = 1;
             }
             dataFile.println(dataString);


### PR DESCRIPTION
A semicolon instead of a colon