### PR TITLE
Add RTC and minor changes

### DIFF
--- a/functions.ino
+++ b/functions.ino
@@ -1703,3 +1703,35 @@ void showbgd(int x, int y, const uint8_t *bmp, int w, int h, uint16_t color, uin
     }
     tft.setAddrWindow(0, 0, tft.width() - 1, tft.height() - 1);
 }
+
+void LCDprintDate() { 
+  // /BL show date + time on top row of the LCD
+  tft.setFont();  //standard system font
+  tft.setTextSize(2);
+  tft.setTextColor(tftcolor(DARKBLUE),tftcolor(BLACK));
+
+  // get the date / time from the RTC
+  Time t = rtc.time();
+  // Show time and date on screen
+  char buf[50];
+  snprintf(buf, sizeof(buf), "%04d-%02d-%02d %02d:%02d:%02d",
+           // day.c_str(),
+           t.yr, t.mon, t.date,
+           t.hr, t.min, t.sec);
+  tft.setCursor(10,0);
+  //Serial.println(buf);
+  tft.println(buf);
+}
+
+uint16_t tftcolor(uint16_t basecolor) {
+    // Function to return a color value depending on the time of day.
+    if (basecolor == BLACK) {
+            return basecolor;  // No need to do difficult with dimming BLACK
+    } else {
+        Time t = rtc.time();
+                                        //0Brrrrrggggggbbbbb - colorbits per color
+        uint16_t nightcolor = basecolor & 0b0011100111100111; // let's try this one... (drop 2 hi bits per color)
+        if ((t.hr >= DAYSTARTHR) && (t.hr <= DAYENDHR)) {  return basecolor;  } // day color
+        else                                            {  return nightcolor; } // night color
+    }
+}

--- a/setup.ino
+++ b/setup.ino
@@ -5,7 +5,9 @@
 void setup(void)
 {
   /* --- Start serial & print sketch info --- */
-  Serial.begin(9600);
+  Serial.begin(115200);
+  Serial.print("---------------------------------- ");
+  Serial.print(SWversion);
   Serial.println("----------------------------------");
   Serial.print("Arduino is running Sketch: ");
   Serial.println(__FILE__);
@@ -127,10 +129,12 @@ void setup(void)
   //read value for AS3935_SPI out of EEPROM memory
   AS3935_SPI = EEPROM.read(AS3935_SPI_EEPROMaddr);
   //Serial.print("AS3935_SPI = "); Serial.println(AS3935_SPI);
+  String lightning_interface;
   if(AS3935_SPI)
   {
-    //SPI interface 
-    Serial.println(" SPI");
+    //SPI interface
+    lightning_interface = " SPI"; 
+    Serial.println(lightning_interface);
     AS3935_SPI = true;    //set in case it's not properly set
 
     SPI.begin(); // For SPI
@@ -156,7 +160,8 @@ void setup(void)
   else
   {
     //IIC interface
-    Serial.println(" IIC");
+    lightning_interface = " IIC";
+    Serial.println(lightning_interface);
     AS3935_SPI = false;  //set in case it's not properly set
 
     Serial.print("Scanning at address 0x");
@@ -199,12 +204,14 @@ void setup(void)
       Serial.println();  
   }
   else
-  {
-      Serial.println("Lightning sensor did not start up!");
+  {  
+      Serial.print("Lightning sensor did not start up! Interface used:");
+      Serial.println(lightning_interface);
+      Serial.println("Verify the hardware interface and SET it on the setup screen"); 
       Serial.println(); 
       tft.setTextColor(RED); 
       tft.print("ERROR");
-      delay(1000);
+      delay(3000);
   }
 
   
@@ -285,6 +292,21 @@ void setup(void)
      tft.print("NOT FOUND");
   }
   Serial.println();
+  
+  // see if we do have a Real Time Clock running:
+  Time t = rtc.time();  
+  if (t.mon == 165) {
+    RTC_running = false;
+    Serial.println("No Real Time Clock available");
+  } else {
+    RTC_running = true;
+    Serial.print("Real Time Clock available. Date/time now: ");
+    char buf[20];
+    sprintf(buf, "%04d-%02d-%02d %02d:%02d:%02d", t.yr, t.mon, t.date, t.hr, t.min, t.sec);
+    Serial.println(buf);
+    Serial.println("");
+  }
+
   
   /* --- end of boot, wait 2 secs & set interrupt state, then show info screen --- */
   delay(2000);


### PR DESCRIPTION
Add Real Time Clock but keep the result as original if no RTC chip available.

Change log:
// /BL 20190921 DONE: Print the SWversion at start to Serial
// /BL 20190921 DONE: Add Real Time Clock
//                    Write date/time to log record if RTC clock is running
//                    and millis (as original) if no RTC is running.

// /BL 20190921 DONE: In case the lightning sensor does not start OK: 
//                    - show the error a bit longer
//                    - show the active interface SPI / IIC. 
//                    - Suggest: check the interface and set it correct on the settings panel. 
//                    But maybe we should try IIC interface first and if that fails try SPI
//                    just in case the hardware is set for SPI. Would prevent customer problems (maybe)

/BL 20190922 DONE: Make the color BLUE a bit lighter
                   and define DARKBLUE like BLUE was.
                   The original BLUE was hard to see on the black background.
/BL 20190922 DONE: Report the size of the log file to Serial
/BL 20190922 DONE: Set Serial monitor baud rate to 115200 as I have that on all my sketches
/BL 20190922 DONE: Set humidity compensation to 2 (was 17) for my situation

/BL 20190923 DONE: For better readability: use fontsize 2 on some parts of the info screen.
